### PR TITLE
Remove redux-api-middleware since it breaks the node resolving

### DIFF
--- a/packages/roc-package-web-app-react/app/shared/flux/middlewares/index.js
+++ b/packages/roc-package-web-app-react/app/shared/flux/middlewares/index.js
@@ -1,4 +1,3 @@
-import { apiMiddleware } from 'redux-api-middleware';
 import thunk from 'redux-thunk';
 
-export default [thunk, apiMiddleware];
+export default [thunk];

--- a/packages/roc-package-web-app-react/package.json
+++ b/packages/roc-package-web-app-react/package.json
@@ -42,7 +42,6 @@
     "react-router": "~1.0.0",
     "react-server-status": "~1.0.0",
     "redux": "~3.0.2",
-    "redux-api-middleware": "vgno/redux-api-middleware#v1.0.0-beta5",
     "redux-devtools": "v3.0.0-beta-3",
     "redux-devtools-dock-monitor": "1.0.0-beta-3",
     "redux-devtools-log-monitor": "1.0.0-beta-3",


### PR DESCRIPTION
This because it makes npm resolve babel6 to the root of the node_modules folder.
A better solution should be done later.
