### PR TITLE
Fixes so React Router Redux is used on the server and in production

### DIFF
--- a/packages/roc-package-web-app-react/app/shared/flux/create-store.js
+++ b/packages/roc-package-web-app-react/app/shared/flux/create-store.js
@@ -20,6 +20,9 @@ export default function createReduxStore(reducers, ...middlewares) {
         (history, initialState) => {
             let finalCreateStore;
 
+            // Add the react-router-redux middleware
+            middlewares.push(routerMiddleware(history));
+
             if (__DEV__ && __WEB__) {
                 const { persistState } = require('redux-devtools');
                 const createLogger = require('redux-logger');
@@ -32,8 +35,6 @@ export default function createReduxStore(reducers, ...middlewares) {
 
                 const debugMiddlewares = [logger];
 
-                // Add the react-router-redux middleware
-                middlewares.push(routerMiddleware(history));
                 const devTools = window.devToolsExtension
                     ? window.devToolsExtension()
                     // TODO Enable maxAge support here. Will require a fix for validations in roc


### PR DESCRIPTION
The only potential _"issue"_ with this change is that we are now also running the router middleware on the server but this is verified to work correctly in the complex example and also something that is supported by `react-router-redux`. 
