### PR TITLE
Changed react-router-redux to a temporary fork that fixes routing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 language: node_js
 node_js:
-    - 4.2
     - stable
 before_script:
     - npm run link

--- a/packages/roc-package-web-app-react/package.json
+++ b/packages/roc-package-web-app-react/package.json
@@ -38,7 +38,7 @@
     "react-redux": "~4.4.5",
     "react-router": "~2.3.0",
     "react-router-redial": "~0.2.1",
-    "react-router-redux": "~4.0.2",
+    "react-router-redux": "dlmr/react-router-redux#fix-inital-server-load-dist",
     "react-server-status": "~1.0.0",
     "redial": "~0.4.1",
     "redux": "~3.4.0",


### PR DESCRIPTION
Hopefully we will be able to swap back to the official version when https://github.com/reactjs/react-router-redux/pull/403 is merged or the issue is solved in some alternative way.
