### PR TITLE
Import only the module actually used from history.js 

### DIFF
--- a/extensions/roc-package-web-app-react/app/client/create-client.js
+++ b/extensions/roc-package-web-app-react/app/client/create-client.js
@@ -4,7 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Router from 'react-router/lib/Router';
 import useRouterHistory from 'react-router/lib/useRouterHistory';
-import { createHistory } from 'history';
+import createHistory from 'history/lib/createBrowserHistory';
 import { supportsHistory } from 'history/lib/DOMUtils';
 import debug from 'debug';
 import { RedialContext } from 'react-router-redial';


### PR DESCRIPTION
Haven't been able to test this (not sure how?) but it should be a safe change.

This will reduce the size of client bundles a bit and closes #32.
