### PR TITLE
Made it easier to take ownership over the server entry point

### DIFF
--- a/extensions/roc-package-web-app-react/app/default/server.js
+++ b/extensions/roc-package-web-app-react/app/default/server.js
@@ -1,10 +1,3 @@
 import { createServer, useReact } from '../server';
 
-import getRoutesAndStore from './get-routes-and-store';
-
-const { store, routes } = getRoutesAndStore();
-
-useReact(createServer)({
-    createRoutes: routes,
-    createStore: store,
-}).start();
+useReact(createServer)().start();

--- a/extensions/roc-package-web-app-react/app/server/useReact.js
+++ b/extensions/roc-package-web-app-react/app/server/useReact.js
@@ -3,6 +3,9 @@
 import useReactLib from 'roc-package-web-app-react/lib/app/server/useReact';
 
 import Header from '../shared/header';
+import getRoutesAndStore from '../default/get-routes-and-store';
+
+const { store, routes } = getRoutesAndStore();
 
 export default function useReact(createServer) {
     // eslint-disable-next-line
@@ -13,7 +16,7 @@ export default function useReact(createServer) {
         reduxSagas = require(REDUX_SAGAS).default; // eslint-disable-line
     }
 
-    return useReactLib(createServer, {
+    return ({ createRoutes = routes, createStore = store, ...rest } = {}) => useReactLib(createServer, {
         dev: __DEV__,
         dist: __DIST__,
         hasTemplateValues: HAS_TEMPLATE_VALUES,
@@ -21,5 +24,9 @@ export default function useReact(createServer) {
         rocPath: ROC_PATH,
         Header,
         reduxSagas,
+    })({
+        createRoutes,
+        createStore,
+        ...rest,
     });
 }


### PR DESCRIPTION
This by not having to provide createRoutes and createStore by default.

This means that you can create your own server entry point like this for example:

``` js
import { createServer, useReact } from 'roc-package-web-app-react/app/server';
import session from 'koa-session';

const { server: app, start } = useReact(createServer)();

app.keys = ['some secret hurr'];
app.use(session(app));

start();
```
