### PR TITLE
Support async routes with SSR

### DIFF
--- a/examples/complex/src/components/app/index.js
+++ b/examples/complex/src/components/app/index.js
@@ -19,6 +19,7 @@ export default class App extends Component {
                         <li><IndexLink to="/">Home</IndexLink></li>
                         <li><Link to="/about/">About</Link></li>
                         <li><Link to="/simple/">Simple</Link></li>
+                        <li><Link to="/async/">Async</Link></li>
                     </ul>
                 </nav>
                 { this.props.children }

--- a/examples/complex/src/components/async/index.js
+++ b/examples/complex/src/components/async/index.js
@@ -1,0 +1,11 @@
+import React, { Component } from 'react';
+
+export default class Async extends Component {
+    render() {
+        return (
+            <div>
+                Such asynchronously rendered!
+            </div>
+        );
+    }
+}

--- a/examples/complex/src/routes.js
+++ b/examples/complex/src/routes.js
@@ -15,7 +15,7 @@ export default () => (
         <Route
             path="async"
             getComponent={ (nextState, callback) => {
-                require.ensure([], () => {
+                require.ensure([], (require) => {
                     const Async = require('./components/async').default;
                     callback(
                         null,

--- a/examples/complex/src/routes.js
+++ b/examples/complex/src/routes.js
@@ -12,5 +12,18 @@ export default () => (
         <IndexRoute component={ Main } value={true}/>
         <Route path="about/" component={ About } data={2} />
         <Route path="simple/" component={ Simple } data={3} />
+        <Route
+            path="async"
+            getComponent={ (nextState, callback) => {
+                require.ensure([], () => {
+                    const Async = require('./components/async').default;
+                    callback(
+                        null,
+                        Async
+                    );
+                });
+            }}
+            data={4}
+        />
     </Route>
 );

--- a/extensions/roc-package-web-app-react-dev/.eslintrc
+++ b/extensions/roc-package-web-app-react-dev/.eslintrc
@@ -3,7 +3,7 @@
 
     "parser": "babel-eslint",
 
-    plugins: ["eslint-plugin-babel"],
+    "plugins": ["eslint-plugin-babel"],
 
     "rules": {
         "indent": [2, 4, { "SwitchCase": 1 }],
@@ -11,7 +11,7 @@
         "no-warning-comments": 1,
 
         "generator-star-spacing": 0,
-        "babel/generator-star-spacing": [2, { before: false, after: true }],
+        "babel/generator-star-spacing": [2, { "before": false, "after": true }],
 
         "import/order": [2, { "groups": ["builtin", "external", "internal", "parent", "sibling", "index"], "newlines-between": "always"}],
         "import/newline-after-import": [2],

--- a/extensions/roc-package-web-app-react/.eslintrc
+++ b/extensions/roc-package-web-app-react/.eslintrc
@@ -3,7 +3,7 @@
 
     "parser": "babel-eslint",
 
-    plugins: ["eslint-plugin-babel"],
+    "plugins": ["eslint-plugin-babel"],
 
     "rules": {
         "indent": [2, 4, { "SwitchCase": 1 }],
@@ -13,7 +13,7 @@
         "arrow-parens": ["off", "as-needed"],
 
         "generator-star-spacing": 0,
-        "babel/generator-star-spacing": [2, { before: false, after: true }],
+        "babel/generator-star-spacing": [2, { "before": false, "after": true }],
 
         "import/order": [2, { "groups": ["builtin", "external", "internal", "parent", "sibling", "index"], "newlines-between": "always"}],
         "import/newline-after-import": [2],

--- a/extensions/roc-package-web-app-react/app/client/create-client.js
+++ b/extensions/roc-package-web-app-react/app/client/create-client.js
@@ -67,8 +67,6 @@ export default function createClient({ createRoutes, createStore, mountNode }) {
     }
 
     const render = () => {
-        const node = document.getElementById(mountNode);
-
         const forceRefreshSetting = rocConfig.runtime.history.forceRefresh;
         let history = useRouterHistory(createHistory)({
             basename,
@@ -149,30 +147,29 @@ export default function createClient({ createRoutes, createStore, mountNode }) {
             ));
         }
 
-        let initialLoading;
-        if (HAS_CLIENT_LOADING) {
-            initialLoading = require(ROC_CLIENT_LOADING).default;
-        }
+        const node = document.getElementById(mountNode);
         let updateScroll = () => {};
-        renderToDOM({
-            node,
-            createComponent: compose(...createComponent),
-            history,
-            routes,
-            routerRenderFn: applyRouterMiddleware(
-                useScroll({
-                    updateScroll: (cb) => { updateScroll = cb; },
-                }),
-                useRedial({
-                    locals,
-                    initialLoading,
-                    beforeTransition: rocConfig.runtime.fetch.client.beforeTransition,
-                    afterTransition: rocConfig.runtime.fetch.client.afterTransition,
-                    parallel: rocConfig.runtime.fetch.client.parallel,
-                    onCompleted: (type) => type === 'beforeTransition' && updateScroll(),
-                })
-            ),
-        });
+        renderToDOM(
+            {
+                createComponent: compose(...createComponent),
+                history,
+                routes,
+                routerRenderFn: applyRouterMiddleware(
+                    useScroll({
+                        updateScroll: (cb) => { updateScroll = cb; },
+                    }),
+                    useRedial({
+                        locals,
+                        initialLoading: HAS_CLIENT_LOADING ? require(ROC_CLIENT_LOADING).default : undefined,
+                        beforeTransition: rocConfig.runtime.fetch.client.beforeTransition,
+                        afterTransition: rocConfig.runtime.fetch.client.afterTransition,
+                        parallel: rocConfig.runtime.fetch.client.parallel,
+                        onCompleted: (type) => type === 'beforeTransition' && updateScroll(),
+                    })
+                ),
+            },
+            node
+        );
 
         if (__DEV__) {
             const devNode = document.createElement('div');

--- a/extensions/roc-package-web-app-react/app/client/render-to-dom.js
+++ b/extensions/roc-package-web-app-react/app/client/render-to-dom.js
@@ -1,0 +1,42 @@
+/* eslint-disable global-require */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Router from 'react-router/lib/Router';
+import match from 'react-router/lib/match';
+
+import { rocConfig } from '../shared/universal-config';
+
+function renderSync({ renderProps, createComponent, node, routerRenderFn }) {
+    const finalComponent = createComponent(
+        <Router
+            {...renderProps}
+            render={routerRenderFn}
+        />
+    );
+
+    ReactDOM.render(finalComponent, node);
+}
+
+function renderAsync({ history, routes, ...rest }) {
+    match({ history, routes }, (error, redirectLocation, renderProps) => {
+        renderSync({
+            ...rest,
+            renderProps,
+        });
+    });
+}
+
+export default function renderToDOM(props) {
+    if (rocConfig.runtime.ssr) {
+        renderAsync(props);
+    } else {
+        const { history, routes, ...rest } = props;
+        renderSync({
+            ...rest,
+            renderProps: {
+                history,
+                routes,
+            },
+        });
+    }
+}

--- a/extensions/roc-package-web-app-react/app/client/render-to-dom.js
+++ b/extensions/roc-package-web-app-react/app/client/render-to-dom.js
@@ -26,11 +26,11 @@ function renderAsync({ history, routes, ...rest }) {
     });
 }
 
-export default function renderToDOM(props) {
+export default function renderToDOM(options) {
     if (rocConfig.runtime.ssr) {
-        renderAsync(props);
+        renderAsync(options);
     } else {
-        const { history, routes, ...rest } = props;
+        const { history, routes, ...rest } = options;
         renderSync({
             ...rest,
             renderProps: {

--- a/extensions/roc-package-web-app-react/app/client/render-to-dom.js
+++ b/extensions/roc-package-web-app-react/app/client/render-to-dom.js
@@ -4,9 +4,7 @@ import ReactDOM from 'react-dom';
 import Router from 'react-router/lib/Router';
 import match from 'react-router/lib/match';
 
-import { rocConfig } from '../shared/universal-config';
-
-function renderSync({ renderProps, createComponent, node, routerRenderFn }) {
+function renderSync({ renderProps, createComponent, routerRenderFn }, node) {
     const finalComponent = createComponent(
         <Router
             {...renderProps}
@@ -17,26 +15,11 @@ function renderSync({ renderProps, createComponent, node, routerRenderFn }) {
     ReactDOM.render(finalComponent, node);
 }
 
-function renderAsync({ history, routes, ...rest }) {
+export default function renderAsync({ history, routes, ...rest }, node) {
     match({ history, routes }, (error, redirectLocation, renderProps) => {
         renderSync({
             ...rest,
             renderProps,
-        });
+        }, node);
     });
-}
-
-export default function renderToDOM(options) {
-    if (rocConfig.runtime.ssr) {
-        renderAsync(options);
-    } else {
-        const { history, routes, ...rest } = options;
-        renderSync({
-            ...rest,
-            renderProps: {
-                history,
-                routes,
-            },
-        });
-    }
 }


### PR DESCRIPTION
## Problem
Currently, if you utilize asyncronous routes, we get a checksum mismatch between the markup rendered on the server, and the initial client render. This is due to the fact that `react-router` can do asyncronous path matching. On the server, this works without any problems, since `match` is used. On the client, however, if we do a straight `ReactDOM.render(<Router...>)`, then we will render something different then the server if not all routes and components are available synchronously.

## Solution
* Always utilize `match` for the initial render on the client **if server-side rendering** is enabled. This allows us to do async matching in the same way the server does before the initial render.

## WIP
 * [ ] File- and function names might need some ❤️ 
 * [ ] Discussion of the approach and code structure needs further discussion
 * [x] Depends upon dlmr/react-router-redial#13 for proper async route support