### PR TITLE
Feature/intl polyfill

### DIFF
--- a/extensions/roc-package-web-app-react-dev/package.json
+++ b/extensions/roc-package-web-app-react-dev/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "babel-eslint": "~6.1.2",
+    "bundle-loader": "^0.5.4",
     "eslint": "~3.0.1",
     "eslint-config-airbnb-base": "~4.0.0",
     "eslint-plugin-babel": "~3.3.0",

--- a/extensions/roc-package-web-app-react-dev/src/config/roc.config.js
+++ b/extensions/roc-package-web-app-react-dev/src/config/roc.config.js
@@ -13,6 +13,11 @@ export default {
             // Will be moved to redux above eventually, now kept here to make the template upgradable
             reducers: 'src/redux/reducers.js',
 
+            i18n: {
+                usePolyfill: false,
+                locales: [],
+            },
+
             routes: 'src/routes/routes.js',
             useDefaultRoutes: true,
 

--- a/extensions/roc-package-web-app-react-dev/src/config/roc.config.meta.js
+++ b/extensions/roc-package-web-app-react-dev/src/config/roc.config.meta.js
@@ -50,6 +50,15 @@ export default {
                     validator: notEmpty(isPath),
                 },
             },
+            i18n: {
+                usePolyfill: {
+                    description: 'If Roc should load Intl polyfill and locales on client and server.',
+                },
+                locales: {
+                    description: 'List of locales polyfills to load on the client - these are listed in the ' +
+                                 'intl package (see node_modules/intl/locale-date/jsonp/.',
+                },
+            },
             clientLoading: {
                 description: 'The React component to use on the first client load while fetching data, will only ' +
                 'be used if some blocking hooks are defined.',

--- a/extensions/roc-package-web-app-react-dev/src/webpack/index.js
+++ b/extensions/roc-package-web-app-react-dev/src/webpack/index.js
@@ -1,3 +1,5 @@
+import { join } from 'path';
+
 import { getAbsolutePath, fileExists } from 'roc';
 import webpack from 'webpack';
 import ContextReplacementPlugin from 'webpack/lib/ContextReplacementPlugin';
@@ -90,7 +92,7 @@ export default ({
                 I18N_LOCALES: JSON.stringify(locales),
             }),
             new ContextReplacementPlugin(
-                new RegExp('intl/locale-data/jsonp$'),
+                /intl[\/\\]locale-data[\/\\]jsonp$/,
                 new RegExp(`^\.\/(${locales.join('|')})$`)
             )
         );
@@ -110,6 +112,8 @@ export default ({
             HAS_TEMPLATE_VALUES: hasTemplateValues,
         })
     );
+
+    newWebpackConfig.resolveLoader.root.push(join(__dirname, '..', '..', 'node_modules'));
 
     return newWebpackConfig;
 };

--- a/extensions/roc-package-web-app-react-dev/src/webpack/index.js
+++ b/extensions/roc-package-web-app-react-dev/src/webpack/index.js
@@ -1,5 +1,6 @@
 import { getAbsolutePath, fileExists } from 'roc';
 import webpack from 'webpack';
+import ContextReplacementPlugin from 'webpack/lib/ContextReplacementPlugin';
 
 export default ({
     context: { config: { settings: { build: buildSettings } } },
@@ -80,11 +81,27 @@ export default ({
         );
     }
 
+    const hasI18nLocales = !!(buildSettings.i18n.locales && buildSettings.i18n.locales.length);
+    if (hasI18nLocales) {
+        const locales = buildSettings.i18n.locales;
+
+        newWebpackConfig.plugins.push(
+            new webpack.DefinePlugin({
+                I18N_LOCALES: JSON.stringify(locales),
+            }),
+            new ContextReplacementPlugin(
+                new RegExp('intl/locale-data/jsonp$'),
+                new RegExp(`^\.\/(${locales.join('|')})$`)
+            )
+        );
+    }
+
     newWebpackConfig.plugins.push(
         new webpack.DefinePlugin({
             USE_DEFAULT_REDUX_REDUCERS: buildSettings.redux.useDefaultReducers,
             USE_DEFAULT_REDUX_MIDDLEWARES: buildSettings.redux.useDefaultMiddlewares,
             USE_DEFAULT_REACT_ROUTER_ROUTES: buildSettings.useDefaultRoutes,
+            USE_I18N_POLYFILL: buildSettings.i18n.usePolyfill,
 
             HAS_REDUX_REDUCERS: hasReducers,
             HAS_REDUX_MIDDLEWARES: hasMiddlewares,

--- a/extensions/roc-package-web-app-react/app/client/create-client.js
+++ b/extensions/roc-package-web-app-react/app/client/create-client.js
@@ -194,14 +194,15 @@ export default function createClient({ createRoutes, createStore, mountNode }) {
                 require('intl');
             }
 
-            I18N_LOCALES.forEach(locale => {
-                if (!areIntlLocalesSupported(locale)) {
-                    // eslint-disable-next-line
-                    require('intl/locale-data/jsonp/' + locale);
-                }
+            // eslint-disable-next-line
+            require.ensure([], require => {
+                I18N_LOCALES.forEach(locale => {
+                    if (!areIntlLocalesSupported(locale)) {
+                        // eslint-disable-next-line
+                        require('intl/locale-data/jsonp/' + locale);
+                    }
+                });
             });
-
-            render();
         });
     } else {
         render();

--- a/extensions/roc-package-web-app-react/app/client/create-client.js
+++ b/extensions/roc-package-web-app-react/app/client/create-client.js
@@ -191,6 +191,9 @@ export default function createClient({ createRoutes, createStore, mountNode }) {
             require('bundle?name=intl!intl') :
             (cb) => cb();
 
+        // intl's locale data identifies locales by the shortest ISO 639 language code.
+        // https://tools.ietf.org/html/rfc5646
+        const language = (locale) => /^([^-]+)/.exec(locale)[0];
 
         intlLoader(() => {
             const areIntlLocalesSupported = require('intl-locales-supported');
@@ -198,7 +201,7 @@ export default function createClient({ createRoutes, createStore, mountNode }) {
             const localeModules = I18N_LOCALES.map(locale => new Promise((resolve) => {
                 if (!areIntlLocalesSupported(locale)) {
                     // eslint-disable-next-line
-                    require('bundle!intl/locale-data/jsonp/' + locale)(resolve);
+                    require('bundle!intl/locale-data/jsonp/' + language(locale))(resolve);
                 } else {
                     resolve();
                 }

--- a/extensions/roc-package-web-app-react/app/client/create-client.js
+++ b/extensions/roc-package-web-app-react/app/client/create-client.js
@@ -1,5 +1,5 @@
 /* global __DEV__, HAS_CLIENT_LOADING, ROC_CLIENT_LOADING, ROC_PATH, HAS_REDUX_REDUCERS, document, window,
- HAS_REDUX_SAGA, REDUX_SAGAS */
+ HAS_REDUX_SAGA, REDUX_SAGAS, I18N_LOCALES, USE_I18N_POLYFILL */
 /* eslint-disable global-require */
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -186,5 +186,24 @@ export default function createClient({ createRoutes, createStore, mountNode }) {
         }
     };
 
-    render();
+    if (USE_I18N_POLYFILL) {
+        require.ensure([], require => {
+            const areIntlLocalesSupported = require('intl-locales-supported');
+
+            if (!global.Intl) {
+                require('intl');
+            }
+
+            I18N_LOCALES.forEach(locale => {
+                if (!areIntlLocalesSupported(locale)) {
+                    // eslint-disable-next-line
+                    require('intl/locale-data/jsonp/' + locale);
+                }
+            });
+
+            render();
+        });
+    } else {
+        render();
+    }
 }

--- a/extensions/roc-package-web-app-react/app/server/useReact.js
+++ b/extensions/roc-package-web-app-react/app/server/useReact.js
@@ -1,4 +1,5 @@
-/* global __DIST__, __DEV__ HAS_TEMPLATE_VALUES, TEMPLATE_VALUES, ROC_PATH, HAS_REDUX_SAGA, REDUX_SAGAS */
+/* global __DIST__, __DEV__ HAS_TEMPLATE_VALUES, TEMPLATE_VALUES, ROC_PATH, HAS_REDUX_SAGA, REDUX_SAGAS,
+ I18N_LOCALES, USE_I18N_POLYFILL */
 
 import useReactLib from 'roc-package-web-app-react/lib/app/server/useReact';
 
@@ -14,6 +15,24 @@ export default function useReact(createServer) {
 
     if (HAS_REDUX_SAGA) {
         reduxSagas = require(REDUX_SAGAS).default; // eslint-disable-line
+    }
+
+    if (USE_I18N_POLYFILL) {
+        // eslint-disable-next-line
+        const areIntlLocalesSupported = require('intl-locales-supported');
+
+        if (global.Intl) {
+            if (!areIntlLocalesSupported(I18N_LOCALES)) {
+                // eslint-disable-next-line
+                const IntlPolyfill = require('intl');
+
+                Intl.NumberFormat = IntlPolyfill.NumberFormat;
+                Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
+            }
+        } else {
+            // eslint-disable-next-line
+            global.Intl = require('intl');
+        }
     }
 
     return ({ createRoutes = routes, createStore = store, ...rest } = {}) => useReactLib(createServer, {

--- a/extensions/roc-package-web-app-react/app/server/useReact.js
+++ b/extensions/roc-package-web-app-react/app/server/useReact.js
@@ -21,17 +21,12 @@ export default function useReact(createServer) {
         // eslint-disable-next-line
         const areIntlLocalesSupported = require('intl-locales-supported');
 
-        if (global.Intl) {
-            if (!areIntlLocalesSupported(I18N_LOCALES)) {
-                // eslint-disable-next-line
-                const IntlPolyfill = require('intl');
-
-                Intl.NumberFormat = IntlPolyfill.NumberFormat;
-                Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
-            }
-        } else {
+        if (!areIntlLocalesSupported(I18N_LOCALES)) {
             // eslint-disable-next-line
-            global.Intl = require('intl');
+            const IntlPolyfill = require('intl');
+
+            Intl.NumberFormat = IntlPolyfill.NumberFormat;
+            Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
         }
     }
 

--- a/extensions/roc-package-web-app-react/package.json
+++ b/extensions/roc-package-web-app-react/package.json
@@ -32,6 +32,8 @@
     "debug": "~2.2.0",
     "error": "~7.0.2",
     "history": "^2.1.0",
+    "intl": "^1.2.5",
+    "intl-locales-supported": "^1.0.0",
     "nunjucks": "~2.4.2",
     "pretty-error": "~2.0.0",
     "react-helmet": "~3.1.0",

--- a/extensions/roc-package-web-app-react/src/roc/index.js
+++ b/extensions/roc-package-web-app-react/src/roc/index.js
@@ -17,6 +17,8 @@ export default {
     dependencies: {
         exports: generateDependencies(packageJSON, [
             'history',
+            'intl',
+            'intl-locales-supported',
             'react-helmet',
             'react-redux',
             'react-router',


### PR DESCRIPTION
This adds Intl Polyfill support to both the server and browser.

Node ships with just an en locale as standard so additional locales may be required.

All specified languages are bundled in a single bundle.

To test add to your build settings and either test in a browser that does not support Intl (such as safari pre 10.00, or set global.Intl to null before roc application startup).

```
settings: {
  build: { 
    i18n: {
      usePolyfill: true,
      locales: ['en','nb']
    }
  }
}
```

This PR does not add react-intl support as that can currently be easily added in `screens/app/index.js`

Files are bundled separately and only loaded when needed. Locales are loaded in parallel:

On an iPad running iOS 9 (No Intl support): 
![screen shot 2016-11-13 at 13 40 05](https://cloud.githubusercontent.com/assets/45935/20246079/12cec7dc-a9a7-11e6-9a80-55ffaa70ac8a.png)


On macOs 10.12 running Safari 10.0.1 (Intl support):
![screen shot 2016-11-13 at 13 42 11](https://cloud.githubusercontent.com/assets/45935/20246080/16a01492-a9a7-11e6-920f-015a18dcbfa2.png)

           