### PR TITLE
Support redirects on the server side triggered by history modifications

### DIFF
--- a/extensions/roc-package-web-app-react/app/client/create-client.js
+++ b/extensions/roc-package-web-app-react/app/client/create-client.js
@@ -92,7 +92,9 @@ export default function createClient({ createRoutes, createStore, mountNode }) {
         }
 
         let routes;
-        let locals = {};
+        let locals = {
+            history,
+        };
         const createComponent = [(component) => component];
         const createDevComponent = [(component) => component];
 
@@ -117,6 +119,7 @@ export default function createClient({ createRoutes, createStore, mountNode }) {
             locals = {
                 dispatch: store.dispatch,
                 getState: store.getState,
+                history,
             };
 
             createComponent.push((component) => (

--- a/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
+++ b/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
@@ -82,6 +82,12 @@ export function reactRender({
     reduxSagas,
 }) {
     return new Promise((resolve) => {
+        let currentLocation = {};
+
+        history.listen((location) => {
+            currentLocation = location;
+        });
+
         match({ history, routes: createRoutes(store), location: url },
             (error, redirect, renderProps) => {
                 if (redirect) {
@@ -126,6 +132,15 @@ export function reactRender({
                     }
                     return result;
                 }).then(({ redialMap, redialProps }) => {
+                    const currentUrl = currentLocation.pathname + currentLocation.search;
+
+                    if (currentUrl !== url) {
+                        log(`Redirect request to ${currentUrl}`);
+                        return resolve({
+                            redirect: currentUrl,
+                        });
+                    }
+
                     let component = applyRouterMiddleware(useRedial({ redialMap }))(renderProps);
 
                     if (store) {

--- a/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
+++ b/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
@@ -82,7 +82,7 @@ export function reactRender({
     reduxSagas,
 }) {
     return new Promise((resolve) => {
-        let currentLocation = {};
+        let currentLocation;
 
         history.listen((location) => {
             currentLocation = location;
@@ -91,7 +91,7 @@ export function reactRender({
         match({ history, routes: createRoutes(store), location: url },
             (error, redirect, renderProps) => {
                 if (redirect) {
-                    const base = redirect.basename ? redirect.basename : '';
+                    const base = redirect.basename || '';
                     const redirectUrl = `${base}${redirect.pathname}${redirect.search}`;
                     log(`Redirect request to ${redirectUrl} due to React Router`);
 
@@ -138,11 +138,11 @@ export function reactRender({
                     }
                     return result;
                 }).then(({ redialMap, redialProps }) => {
-                    if (Object.keys(currentLocation).length > 0) {
+                    if (currentLocation) {
                         const currentUrl = `${currentLocation.pathname}${currentLocation.search}`;
 
                         if (currentUrl !== url) {
-                            const base = currentLocation.basename ? currentLocation.basename : '';
+                            const base = currentLocation.basename || '';
                             const redirectUrl = `${base}${currentUrl}`;
 
                             log(`Redirect request to ${redirectUrl} due to history location modification`);

--- a/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
+++ b/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
@@ -91,9 +91,12 @@ export function reactRender({
         match({ history, routes: createRoutes(store), location: url },
             (error, redirect, renderProps) => {
                 if (redirect) {
-                    log(`Redirect request to ${redirect.pathname + redirect.search}`);
+                    const base = redirect.basename ? redirect.basename : '';
+                    const redirectUrl = `${base}${redirect.pathname}${redirect.search}`;
+                    log(`Redirect request to ${redirectUrl} due to React Router`);
+
                     return resolve({
-                        redirect: redirect.pathname + redirect.search,
+                        redirect: redirectUrl,
                     });
                 } else if (error) {
                     log('Router error', pretty.render(error));
@@ -135,15 +138,18 @@ export function reactRender({
                     }
                     return result;
                 }).then(({ redialMap, redialProps }) => {
-                    const currentUrl = `${currentLocation.pathname}${currentLocation.search}`;
+                    if (Object.keys(currentLocation).length > 0) {
+                        const currentUrl = `${currentLocation.pathname}${currentLocation.search}`;
 
-                    if (currentUrl !== url) {
-                        const base = currentLocation.basename ? currentLocation.basename : '';
+                        if (currentUrl !== url) {
+                            const base = currentLocation.basename ? currentLocation.basename : '';
+                            const redirectUrl = `${base}${currentUrl}`;
 
-                        log(`Redirect request to ${base}${currentUrl} due to history location modification`);
-                        return resolve({
-                            redirect: `${base}${currentUrl}`,
-                        });
+                            log(`Redirect request to ${redirectUrl} due to history location modification`);
+                            return resolve({
+                                redirect: `${redirectUrl}`,
+                            });
+                        }
                     }
 
                     let component = applyRouterMiddleware(useRedial({ redialMap }))(renderProps);

--- a/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
+++ b/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
@@ -132,12 +132,14 @@ export function reactRender({
                     }
                     return result;
                 }).then(({ redialMap, redialProps }) => {
-                    const currentUrl = currentLocation.pathname + currentLocation.search;
+                    const currentUrl = `${currentLocation.pathname}${currentLocation.search}`;
 
                     if (currentUrl !== url) {
-                        log(`Redirect request to ${currentUrl}`);
+                        const base = currentLocation.basename ? currentLocation.basename : '';
+
+                        log(`Redirect request to ${base}${currentUrl} due to history location modification`);
                         return resolve({
-                            redirect: currentUrl,
+                            redirect: `${base}${currentUrl}`,
                         });
                     }
 

--- a/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
+++ b/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
@@ -112,7 +112,10 @@ export function reactRender({
                 const locals = store ? {
                     dispatch: store.dispatch,
                     getState: store.getState,
-                } : {};
+                    history,
+                } : {
+                    history,
+                };
 
                 const hooks = rocConfig.runtime.fetch.server;
 


### PR DESCRIPTION
This change ensures that modifications to the history object that should result in a redirect is respected on the server side, e.g a dispatch of 'replace' using `react-router-redux`.
Without this, the sever will provide a 200 OK, and then the URL is modified on the client-side only.

Checklist:
- [x] Works as before without Redux
- [x] Works when things like basePath are used
