### PR TITLE
Upgrade `react-redux` to `^v5.0.1`

### DIFF
--- a/extensions/roc-package-web-app-react/package.json
+++ b/extensions/roc-package-web-app-react/package.json
@@ -37,7 +37,7 @@
     "nunjucks": "~2.4.2",
     "pretty-error": "~2.0.0",
     "react-helmet": "~3.1.0",
-    "react-redux": "~4.4.5",
+    "react-redux": "^5.0.1",
     "react-router": "~2.8.1",
     "react-router-redial": "~0.3.0",
     "react-router-redux": "~4.0.2",


### PR DESCRIPTION
This PR upgrades `react-redux` to next major version. The performance increase is substantial and the API is backwards compatible, so should cause no issues for consumers.

Additionally, changed the semver version range to `^` instead of `~`. Thoughts?