### PR TITLE
Added new data to the template that can be used when rendering

### DIFF
--- a/extensions/roc-package-web-app-react/src/app/server/reactRouter.js
+++ b/extensions/roc-package-web-app-react/src/app/server/reactRouter.js
@@ -69,6 +69,7 @@ export default function reactRouter({
                     createRoutes,
                     renderPage,
                     koaState: this.state,
+                    request: this.request,
                     hasTemplateValues,
                     templateValues,
                     reduxSagas,


### PR DESCRIPTION
Now the following can also be used in the template.

* `error` - A potential error that might have happened
* `request` - The Koa request
* `status` - The status the page will have when serving the page

Also changed the log message when the React rendering fails. It might not always be because of the fetching, it can be related to the rendering as well.

Closes #49 