### PR TITLE
Added missing argument to useReact wrapper function

### DIFF
--- a/extensions/roc-package-web-app-react/app/server/useReact.js
+++ b/extensions/roc-package-web-app-react/app/server/useReact.js
@@ -30,17 +30,21 @@ export default function useReact(createServer) {
         }
     }
 
-    return ({ createRoutes = routes, createStore = store, ...rest } = {}) => useReactLib(createServer, {
-        dev: __DEV__,
-        dist: __DIST__,
-        hasTemplateValues: HAS_TEMPLATE_VALUES,
-        templateValues,
-        rocPath: ROC_PATH,
-        Header,
-        reduxSagas,
-    })({
-        createRoutes,
-        createStore,
-        ...rest,
-    });
+    return ({ createRoutes = routes, createStore = store, ...rest } = {}, beforeUserMiddlewares) =>
+        useReactLib(createServer, {
+            dev: __DEV__,
+            dist: __DIST__,
+            hasTemplateValues: HAS_TEMPLATE_VALUES,
+            templateValues,
+            rocPath: ROC_PATH,
+            Header,
+            reduxSagas,
+        })(
+            {
+                createRoutes,
+                createStore,
+                ...rest,
+            },
+            beforeUserMiddlewares
+        );
 }


### PR DESCRIPTION
Adds `beforeUserMiddlewares` to the `/app` code. This makes it easy to define middlewares in code that is added before the React rendering.