### PR TITLE
htmlAttributes must call toString in html template

### DIFF
--- a/extensions/roc-package-web-app-react/views/main.html
+++ b/extensions/roc-package-web-app-react/views/main.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html {{ head.htmlAttributes | safe }}>
+<html {{ head.htmlAttributes.toString() | safe }}>
   <head>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">


### PR DESCRIPTION
If htmlAttributes is used in a html template, we need to call .toString().
https://github.com/nfl/react-helmet#as-string-output

Before:
![before toString](https://cloud.githubusercontent.com/assets/1419214/25332427/b9782e48-28e6-11e7-8562-8eeba49f3d88.png)

After:
![after toString](https://cloud.githubusercontent.com/assets/1419214/25332476/e0f75ee4-28e6-11e7-9a55-1c647b811ae0.png)


