### PR TITLE
Make templates extensible and template context configurable by other extensions

### DIFF
--- a/extensions/roc-package-web-app-react-dev/src/config/roc.config.js
+++ b/extensions/roc-package-web-app-react-dev/src/config/roc.config.js
@@ -27,6 +27,7 @@ export default {
             resources: ['roc-package-web-app-react/styles/base.css'],
 
             templateValues: 'src/template-values.js',
+            templateContext: {},
         },
         dev: {
             // A11Y not play nice with Redux Devtools at the moment

--- a/extensions/roc-package-web-app-react-dev/src/config/roc.config.meta.js
+++ b/extensions/roc-package-web-app-react-dev/src/config/roc.config.meta.js
@@ -1,4 +1,4 @@
-import { isString, isBoolean, isPath, isArray, notEmpty, isInteger, required } from 'roc/validators';
+import { isString, isBoolean, isPath, isArray, notEmpty, isInteger, required, isObject } from 'roc/validators';
 
 export default {
     settings: {
@@ -72,6 +72,12 @@ export default {
 
             templateValues: {
                 description: '[UNDOCUMENTED]',
+            },
+            templateContext: {
+                description: 'Custom context data passed to template rendering.',
+                validator: isObject({
+                    unmanaged: true,
+                }),
             },
         },
         dev: {

--- a/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
+++ b/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
@@ -18,6 +18,7 @@ const pretty = new PrettyError();
 const log = debug('roc:react-render');
 
 const rocConfig = getSettings();
+const defaultTemplatePath = `${myPath}/views`;
 
 const whiteListed = () => (
     rocConfig.runtime.configWhitelistProperty ?
@@ -28,8 +29,12 @@ const whiteListed = () => (
 const appConfig = whiteListed();
 
 export function initRenderPage({ script, css }, distMode, devMode, Header) {
-    const templatePath = rocConfig.runtime.template.path || `${myPath}/views`;
-    nunjucks.configure(getAbsolutePath(templatePath), {
+    const templatePaths = []
+        // Put configurable template paths first for higher priority
+        .concat(rocConfig.runtime.template.path || [], defaultTemplatePath)
+        .map(path => getAbsolutePath(path));
+
+    nunjucks.configure(templatePaths, {
         watch: devMode,
     });
 

--- a/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
+++ b/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
@@ -58,6 +58,7 @@ export function initRenderPage({ script, css }, distMode, devMode, Header) {
         }
 
         return nunjucks.render(rocConfig.runtime.template.name, {
+            ...build.templateContext,
             bundleName,
             content,
             custom: customTemplateValues,

--- a/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
+++ b/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
@@ -12,6 +12,8 @@ import { triggerHooks, useRedial } from 'react-router-redial';
 import { getAbsolutePath, getSettings } from 'roc';
 import ServerStatus from 'react-server-status';
 
+import { invokeHook } from '../../roc/util';
+
 import myPath from './helpers/myPath';
 
 const pretty = new PrettyError();
@@ -29,10 +31,12 @@ const whiteListed = () => (
 const appConfig = whiteListed();
 
 export function initRenderPage({ script, css }, distMode, devMode, Header) {
-    const templatePaths = []
-        // Put configurable template paths first for higher priority
-        .concat(rocConfig.runtime.template.path || [], defaultTemplatePath)
-        .map(path => getAbsolutePath(path));
+    const templatePaths = [].concat(
+        // Combine paths from highest priority to lowest
+        rocConfig.runtime.template.path || [],
+        invokeHook('get-template-paths'),
+        defaultTemplatePath
+    ).map(path => getAbsolutePath(path));
 
     nunjucks.configure(templatePaths, {
         watch: devMode,

--- a/extensions/roc-package-web-app-react/src/config/roc.config.meta.js
+++ b/extensions/roc-package-web-app-react/src/config/roc.config.meta.js
@@ -61,9 +61,10 @@ export default {
             },
             template: {
                 path: {
-                    description: 'A directory where the template for the application can be found. ' +
-                        'Will default to internal path.',
-                    validator: notEmpty(isPath),
+                    description: 'A directory, or array of directories, where the template for the application ' +
+                        'can be found. Internal path with default templates will be appended to the array, ' +
+                        'so it\'s possible to extend them.',
+                    validator: notEmpty(oneOf(isPath, isArray(notEmpty(isPath)))),
                 },
                 name: {
                     description: 'Name of the template file that will be used. Uses Nunjucks, please see ' +

--- a/extensions/roc-package-web-app-react/src/roc/index.js
+++ b/extensions/roc-package-web-app-react/src/roc/index.js
@@ -1,5 +1,6 @@
 import { generateDependencies } from 'roc';
 import { warn } from 'roc/log/default/large';
+import { isString, isArray } from 'roc/validators';
 
 import config from '../config/roc.config';
 import meta from '../config/roc.config.meta';
@@ -11,6 +12,14 @@ let warnForReactRouterScroll = true;
 export default {
     config,
     meta,
+    hooks: {
+        'get-template-paths': {
+            description: 'Used to append paths for template files lookup. ' +
+                'Actions should concat the previousValue to build the complete value.',
+            initialValue: [],
+            returns: isArray(isString),
+        },
+    },
     packages: [
         require.resolve('roc-package-web-app'),
     ],

--- a/extensions/roc-package-web-app-react/src/roc/util.js
+++ b/extensions/roc-package-web-app-react/src/roc/util.js
@@ -1,0 +1,15 @@
+import { runHook } from 'roc';
+
+// eslint-disable-next-line
+export const packageJSON = require('../../package.json');
+
+/**
+ * Helper function for invoking/running a hook, pre-configured for the current package.
+ *
+ * @param {...Object} args - The arguments to pass along to the action.
+ *
+ * @returns {Object|function} - Either a object, the final value from the actions or a function if callback is used.
+ */
+export function invokeHook(...args) {
+    return runHook(packageJSON.name)(...args);
+}


### PR DESCRIPTION
Current template configuration allows specifying only a single directory from which you can reference other templates or partials, so it's not possible to modify document template in a composable way (by changing only the things you need and keeping everything else intact).

Another problem is that it's not possible to adjust some parts of the document without fully copying it into a separate template. While there is a powerful system for adding markup to the <head> through react-helmet from `settings.runtime.head`, some external scripts and other resources should be included in the <body> tag to prevent main content loading and rendering delay.

To fix this problem the following changes are proposed:
* add ability to specify multiple templates lookup paths. Nunjucks provides ability to add multiple paths for templates lookup in [`configure()`](https://mozilla.github.io/nunjucks/api.html#configure), so it makes sense to allow not only a single path, but an array of paths too. Name of the default template was changed to prevent name conflicts.
* add ability to provide template context from extensions. Right now some data can be passed in one form or another, but it's either limited (only some parts of Roc config are passed), exposed to the client, or not suitable for runtime generation (like specifying a file in `build.templateValues`).

This change allows extensions to extend template directories list and pass custom data to them, which opens some new possibilities, like:
* creating an extensible base template in custom extensions: the package will only have to add its templates path to the list
* offloading non-essential to the project information (like markup for analytics tracking, performance measurements, etc.), without copying them, but at the same time making it configurable

It's possible to also modify default template `roc-base-template.njk` and group markup into blocks for easy `{% extends %}` without creating a separate template, but I think it will add too much noise and still won't suit everyone's needs

---

For example one can create their own extensible template _my-base-template.njk_ and add it to the paths:

```nunjucks
<html>
  ...
  <body>
    ...
    {% block bodyScripts %}
    <script src="{{ bundleName }}"></script>
    {% endblock %}
```

And then in their project template _index.njk_:
```nunjucks
    {% extends "my-base-template.njk" %}
    {% block bodyScripts %}
    {{ super() }}
    <script src="https://third.party/script.js"></script>
    <noscript><iframe src="https://third.party/script-fallback.html" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
    {% endblock %}
```
