### PR TITLE
Fix minimum version of eslint-plugin-import

### DIFF
--- a/extensions/roc-package-web-app-react/package.json
+++ b/extensions/roc-package-web-app-react/package.json
@@ -58,7 +58,7 @@
     "eslint": "~3.6.0",
     "eslint-config-airbnb": "~11.1.0",
     "eslint-plugin-babel": "~3.3.0",
-    "eslint-plugin-import": "~1.14.0",
+    "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-jsx-a11y": "2.2.1",
     "eslint-plugin-react": "6.2.0"
   },


### PR DESCRIPTION
Current version of package `eslint-config-airbnb-base@7.2.0` (required by `eslint-config-airbnb@~11.1.0`) requires a peer dependency `eslint-plugin-import@^1.16.0`, which is not compatible with current version range.

This conflict results in a missing peer dependency error after running `npm start link` in repo root.

There were some other issues when packages from this repo are `npm link`-ed to projects, but I didn't manage to find a reliable solution.