### PR TITLE
Changed the default behavior for base tag, not including by default

### DIFF
--- a/extensions/roc-package-web-app-react/app/shared/header.js
+++ b/extensions/roc-package-web-app-react/app/shared/header.js
@@ -8,10 +8,10 @@ import { rocConfig } from './universal-config';
 // eslint-disable-next-line
 export default class Header extends React.Component {
     render() {
-        const path = ROC_PATH !== '/' ? ROC_PATH + '/' : ROC_PATH; // eslint-disable-line
-        const base = rocConfig.runtime.head.base.href && path ? {
+        const path = ROC_PATH === '/' ? '' : ROC_PATH + '/'; // eslint-disable-line
+        const base = rocConfig.runtime.head.base.href ? {
             ...rocConfig.runtime.head.base,
-            href: rocConfig.runtime.head.base.href.replace(/ROC_PATH/, path),
+            href: rocConfig.runtime.head.base.href.replace(/^ROC_PATH$/, path),
         } : {};
 
         return (


### PR DESCRIPTION
This change solves two problems when not setting an alternative path:
1. A problem in Safari on iOS related to going back in history
2. Made it easier to use anchor links