### PR TITLE
API making it easy to add React Router middleware configuration

### DIFF
--- a/examples/complex/src/components/app/index.js
+++ b/examples/complex/src/components/app/index.js
@@ -18,6 +18,7 @@ export default class App extends Component {
                     <ul>
                         <li><IndexLink to="/">Home</IndexLink></li>
                         <li><Link to="/about/">About</Link></li>
+                        <li><Link to={{ pathname: '/long/', state: { scrollToTop: true } }}>Long</Link></li>
                         <li><Link to="/simple/">Simple</Link></li>
                     </ul>
                 </nav>

--- a/examples/complex/src/components/long/index.js
+++ b/examples/complex/src/components/long/index.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+
+import Bacon from '../bacon';
+
+export default class Long extends Component {
+    render() {
+        return (
+            <div>
+                <Bacon />
+                <Bacon />
+                <Bacon />
+            </div>
+        );
+    }
+}

--- a/examples/complex/src/routes.js
+++ b/examples/complex/src/routes.js
@@ -5,12 +5,53 @@ import IndexRoute from 'react-router/lib/IndexRoute';
 import App from './components/app';
 import Main from './components/main';
 import About from './components/about';
+import Long from './components/long';
 import Simple from './components/simple';
 
 export default () => (
     <Route component={ App } value={false}>
-        <IndexRoute component={ Main } value={true}/>
-        <Route path="about/" component={ About } data={2} />
+        <IndexRoute component={ Main } value={true} scrollToTop />
+        <Route path="about/" component={ About } data={2} ignoreScrollBehavior />
+        <Route path="long/" component={ Long } />
         <Route path="simple/" component={ Simple } data={3} />
     </Route>
 );
+
+export const middlewareConfig = {
+    'react-router-scroll-async': {
+        /*
+        This function will allow us to do two things.
+
+        1. Prevent the scroll behaviour on routes that has defined
+        ignoreScrollBehavior on them to true or if a link has set
+        the state with ignoreScrollBehavior to true.
+
+        2. Make sure we go to the top of the page if scrollToTop
+        has been defined on the route or on the state of the link
+        transition.
+
+        Route:
+          <Route path="about/" component={ About } ignoreScrollBehavior />
+
+        Link:
+          <Link to={{ pathname: '/some/path', state: { scrollToTop: true } }} />Foo</Link>
+        */
+        shouldUpdateScroll: (prevRouterProps, { routes, location }) => {
+            if (
+                routes.some(route => route.ignoreScrollBehavior) ||
+                location.state && location.state.ignoreScrollBehavior
+            ) {
+                return false;
+            }
+
+            if (
+                routes.some(route => route.scrollToTop) ||
+                location.state && location.state.scrollToTop
+            ) {
+                return [0, 0];
+            }
+
+            return true;
+        },
+    },
+};

--- a/extensions/roc-package-web-app-react/app/default/client.js
+++ b/extensions/roc-package-web-app-react/app/default/client.js
@@ -2,10 +2,11 @@ import { createClient } from '../client';
 
 import getRoutesAndStore from './get-routes-and-store';
 
-const { store, routes } = getRoutesAndStore();
+const { store, routes, routerMiddlewareConfig } = getRoutesAndStore();
 
 createClient({
     createRoutes: routes,
     createStore: store,
     mountNode: 'application',
+    routerMiddlewareConfig,
 });

--- a/extensions/roc-package-web-app-react/app/default/get-routes-and-store.js
+++ b/extensions/roc-package-web-app-react/app/default/get-routes-and-store.js
@@ -56,15 +56,22 @@ export default function getRoutesAndStore() {
         store = storeCreator(replaceReducers);
     }
 
+    const { default: projectRoutes, middlewareConfig = {} } = require(REACT_ROUTER_ROUTES);
+
     if (USE_DEFAULT_REACT_ROUTER_ROUTES) {
         const { createRoutes } = require('../shared');
 
-        routes = createRoutes(require(REACT_ROUTER_ROUTES).default);
+        routes = createRoutes(projectRoutes);
     } else {
         routes = require(REACT_ROUTER_ROUTES).default;
     }
 
     return {
+        routerMiddlewareConfig: {
+            'react-router-scroll-async': {},
+            'react-router-redial': {},
+            ...middlewareConfig,
+        },
         routes,
         store,
     };


### PR DESCRIPTION
This makes it possible to export a `middlewareConfig` object from the routes file that will be used in combination with the Roc settings and defaults.

### Currently supported configuration options
__`react-router-redial`__
```
onStarted(force)           Invoked when a route transition has been detected and when redial hooks will be invoked
onError(error, metaData)   Invoked when an error happens
onAborted(becauseError)    Invoked if it was prematurely aborted through manual interaction or an error
onCompleted(type)          Invoked if everything was completed successfully, with type being either "beforeTransition" or "afterTransition"
```
[See more here.](https://github.com/dlmr/react-router-redial#client-api)

__`react-router-scroll-async`__
```
shouldUpdateScroll         If and how the scroll position should be updated
```
[See more here.](https://github.com/dlmr/react-router-scroll-async#custom-scroll-behavior)

### Example using `shouldUpdateScroll` and `onError`
```js
// routes.js
export default () => /* the application routes */

const forcePageReloadOnError = true;
const goBackOnError = false;

export const middlewareConfig = {
  'react-router-scroll-async': {
    /*
    This function will allow us to do two things.

    1. Prevent the scroll behavior on routes that has defined
    ignoreScrollBehavior on them to true or if a link has set
    the state with ignoreScrollBehavior to true.

    2. Make sure we go to the top of the page if scrollToTop
    has been defined on the route or on the state of the link
    transition.

    Route:
      <Route path="about/" component={ About } ignoreScrollBehavior />

    Link:
      <Link {{ pathname: '/some/path', state: { scrollToTop: true } }} />Foo</Link>
    */
    shouldUpdateScroll: (prevRouterProps, { routes, location }) => {
      if (
        routes.some(route => route.ignoreScrollBehavior) ||
        (location.state && location.state.ignoreScrollBehavior)
      ) {
        return false;
      }

      if (
        routes.some(route => route.scrollToTop) ||
        (location.state && location.state.scrollToTop)
      ) {
        return [0, 0];
      }

      return true;
    },
  },
  'react-router-redial': {
    onError: (err, { abort, beforeTransition, reason, router }) => {
      if (process.env.NODE_ENV !== 'production') {
        console.error(reason, err);
      }

      // We only what to do this if it was a beforeTransition hook that failed
      if (beforeTransition) {
        if (forcePageReloadOnError && reason === 'other') {
          window.location.reload();
        } else if (goBackOnError && reason !== 'location-changed') {
          router.goBack();
        }
        // Abort current loading automatically
        abort();
      }
    },
  },
};
```
