### PR TITLE
feat: Add option to disable react-router-scroll-async

### DIFF
--- a/extensions/roc-package-web-app-react-dev/src/config/roc.config.js
+++ b/extensions/roc-package-web-app-react-dev/src/config/roc.config.js
@@ -19,10 +19,7 @@ export default {
                 locales: [],
             },
 
-            reactRouterScrollAsync: {
-                enabled: true,
-            },
-
+            useReactRouterScrollAsync: true,
             routes: 'src/routes/routes.js',
             useDefaultRoutes: true,
 

--- a/extensions/roc-package-web-app-react-dev/src/config/roc.config.js
+++ b/extensions/roc-package-web-app-react-dev/src/config/roc.config.js
@@ -19,6 +19,10 @@ export default {
                 locales: [],
             },
 
+            reactRouterScrollAsync: {
+                enabled: true,
+            },
+
             routes: 'src/routes/routes.js',
             useDefaultRoutes: true,
 

--- a/extensions/roc-package-web-app-react-dev/src/config/roc.config.meta.js
+++ b/extensions/roc-package-web-app-react-dev/src/config/roc.config.meta.js
@@ -15,6 +15,11 @@ export default {
                     validator: notEmpty(isPath),
                 },
             },
+            useReactRouterScrollAsync: {
+                description: 'Use react-router-scroll-async middleware to help with scroll behavior for ' +
+                    'Single Page Applications. Disable this if SPA functionality is turned off.',
+                validator: required(isBoolean),
+            },
             routes: {
                 description: 'The routes to use if no entry file is given, will use default entry files internally.',
                 validator: notEmpty(isPath),

--- a/extensions/roc-package-web-app-react-dev/src/webpack/index.js
+++ b/extensions/roc-package-web-app-react-dev/src/webpack/index.js
@@ -115,6 +115,7 @@ export default ({
             USE_DEFAULT_REDUX_MIDDLEWARES: buildSettings.redux.useDefaultMiddlewares,
             USE_DEFAULT_REACT_ROUTER_ROUTES: buildSettings.useDefaultRoutes,
             USE_I18N_POLYFILL: buildSettings.i18n.usePolyfill,
+            USE_REACT_ROUTER_SCROLL_ASYNC: buildSettings.reactRouterScrollAsync.enabled,
 
             HAS_REDUX_REDUCERS: hasReducers,
             HAS_REDUX_MIDDLEWARES: hasMiddlewares,

--- a/extensions/roc-package-web-app-react-dev/src/webpack/index.js
+++ b/extensions/roc-package-web-app-react-dev/src/webpack/index.js
@@ -115,7 +115,7 @@ export default ({
             USE_DEFAULT_REDUX_MIDDLEWARES: buildSettings.redux.useDefaultMiddlewares,
             USE_DEFAULT_REACT_ROUTER_ROUTES: buildSettings.useDefaultRoutes,
             USE_I18N_POLYFILL: buildSettings.i18n.usePolyfill,
-            USE_REACT_ROUTER_SCROLL_ASYNC: buildSettings.reactRouterScrollAsync.enabled,
+            USE_REACT_ROUTER_SCROLL_ASYNC: buildSettings.useReactRouterScrollAsync,
 
             HAS_REDUX_REDUCERS: hasReducers,
             HAS_REDUX_MIDDLEWARES: hasMiddlewares,

--- a/extensions/roc-package-web-app-react/app/client/create-client.js
+++ b/extensions/roc-package-web-app-react/app/client/create-client.js
@@ -10,7 +10,6 @@ import createHistory from 'history/lib/createBrowserHistory';
 import { supportsHistory } from 'history/lib/DOMUtils';
 import debug from 'debug';
 import { useRedial } from 'react-router-redial';
-import useScroll from 'react-router-scroll-async/lib/useScroll';
 
 import { rocConfig } from '../shared/universal-config';
 
@@ -172,11 +171,7 @@ export default function createClient({
         let updateScroll = () => {};
 
         const middlewares = [
-            routerMiddlewareConfig['react-router-scroll-async'].disabled !== true && useScroll({
-                ...routerMiddlewareConfig['react-router-scroll-async'],
-                updateScroll: (cb) => { updateScroll = cb; },
-            }),
-            routerMiddlewareConfig['react-router-redial'].disabled !== true && useRedial({
+            useRedial({
                 ...routerMiddlewareConfig['react-router-redial'],
                 locals,
                 initialLoading,
@@ -193,7 +188,17 @@ export default function createClient({
                     }
                 },
             }),
-        ].filter(Boolean);
+        ];
+
+        if(USE_REACT_ROUTER_SCROLL_ASYNC) {
+            const useScroll = require('react-router-scroll-async/lib/useScroll');
+            middlewares.unshift(
+                useScroll({
+                    ...routerMiddlewareConfig['react-router-scroll-async'],
+                    updateScroll: (cb) => { updateScroll = cb; },
+                })
+            );
+        }
 
         const finalComponent = compose(createComponent)(
             <Router

--- a/extensions/roc-package-web-app-react/app/client/create-client.js
+++ b/extensions/roc-package-web-app-react/app/client/create-client.js
@@ -1,5 +1,5 @@
 /* global __DEV__, HAS_CLIENT_LOADING, ROC_CLIENT_LOADING, ROC_PATH, HAS_REDUX_REDUCERS, document, window,
- HAS_REDUX_SAGA, REDUX_SAGAS, I18N_LOCALES, USE_I18N_POLYFILL */
+ HAS_REDUX_SAGA, REDUX_SAGAS, I18N_LOCALES, USE_I18N_POLYFILL, USE_REACT_ROUTER_SCROLL_ASYNC */
 /* eslint-disable global-require */
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -190,8 +190,9 @@ export default function createClient({
             }),
         ];
 
-        if(USE_REACT_ROUTER_SCROLL_ASYNC) {
+        if (USE_REACT_ROUTER_SCROLL_ASYNC) {
             const useScroll = require('react-router-scroll-async/lib/useScroll');
+
             middlewares.unshift(
                 useScroll({
                     ...routerMiddlewareConfig['react-router-scroll-async'],


### PR DESCRIPTION
Add `disabled` flag for optionally disabling router middlewares.

**Example usage**
In `src/shared/routes.js`:
```js
export const middlewareConfig = {
    'react-router-scroll-async': {
        disabled: true,
    },
};
```
