### PR TITLE
Reuse status of caught errors when server rendering

### DIFF
--- a/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
+++ b/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
@@ -252,7 +252,7 @@ export function reactRender({
                         status,
                     });
                 })
-                .catch((err) => {                  
+                .catch((err) => {
                     if (err) {
                         log('General error', pretty.render(err));
                     }

--- a/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
+++ b/extensions/roc-package-web-app-react/src/app/server/reactRenderer.js
@@ -252,13 +252,14 @@ export function reactRender({
                         status,
                     });
                 })
-                .catch((err) => {
+                .catch((err) => {                  
                     if (err) {
                         log('General error', pretty.render(err));
                     }
+                    const { status = 500 } = err || {};
                     return resolve({
-                        status: 500,
-                        body: renderPage({ error: err, request, status: 500 }),
+                        status,
+                        body: renderPage({ error: err, request, status }),
                     });
                 });
             });


### PR DESCRIPTION
Background:
We have koa middlewares checking authentication and setting status 401/403 like 

```js
function* middleWare(ctx, next) {
  if (!isAuthorized(ctx)) {
     ctx.throw(401, 'Missing credentials');
  }
  yield next;
}
```

The status code is currently lost and all responses get http 500 status.