### PR TITLE
Fix `ReactDOM.render(): Invalid component element.`

### DIFF
--- a/extensions/roc-package-web-app-react/app/client/create-client.js
+++ b/extensions/roc-package-web-app-react/app/client/create-client.js
@@ -95,7 +95,7 @@ export default function createClient({
             history,
         };
         const createComponent = [(component) => component];
-        const createDevComponent = [(component) => component];
+        const createDevComponent = [(component) => <div>{component}</div>];
 
         if (HAS_REDUX_REDUCERS && createStore) {
             const { Provider } = require('react-redux');


### PR DESCRIPTION
On a fresh roc init project and with --dev-yellowbox-enabled=false this
error is thrown:

```
Uncaught Error: ReactDOM.render(): Invalid component element.
    at invariant (invariant.js:42)
    at Object._renderSubtreeIntoContainer (ReactMount.js:345)
    at Object.render (ReactMount.js:420)
    at render (create-client.js:213)
    at createClient (create-client.js:241)
    at Object.<anonymous> (client.js:7)
    at __webpack_require__ (bootstrap 3dec2ce…:555)
    at fn (bootstrap 3dec2ce…:86)
    at Object.<anonymous> (bootstrap 3dec2ce…:578)
    at __webpack_require__ (bootstrap 3dec2ce…:555)
```

It is fixed by surrounding the initial component with a div.